### PR TITLE
Removed hardcoded windows pathing, and implemented cli paths to avoid making users edit the code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 1. Clone this Repository
 2. The script depends on `requests`, `beautifulsoup`, `tqdm` and `re`. See `requirements.txt` to create a new conda environment or you can install these packages directly using `pip install requests beautifulsoup4 tqdm` in your desired environment
 3. Set the `url` to the podcast and `out_dir` within the script ([lines 16-17](https://github.com/VaasuDevanS/google-podcast-downloader/blob/c09068092d8807a61fe860ad290517303ceead3e/google-podcast-downloader.py#L16-L17))
+3.5 Alternatively, simply run `python3 google-podcast-downloader.py "<url_to_podcast>" "<Out Directory>"`
 4. Run the script using `python google-podcast-downloader.py`
 5. [Optional] You can change the file name template in [line 44](https://github.com/VaasuDevanS/google-podcast-downloader/blob/c09068092d8807a61fe860ad290517303ceead3e/google-podcast-downloader.py#L44). The default template is `Ep 000 - <Podcast-Name> (<Date-Published>)`
 
@@ -12,6 +13,7 @@
 
 I personally used the script to download the below podcasts for offline listening.
 
+<a href="https://podcasts.google.com/feed/aHR0cHM6Ly9hbmNob3IuZm0vcy85NDFlMWQ4L3BvZGNhc3QvcnNz?sa=X&ved=2ahUKEwit0NGrhoOBAxVIE1kFHeEhBaMQ9sEGegQIARAE"><img src="https://encrypted-tbn2.gstatic.com/images?q=tbn:ANd9GcTm27nk43UwjX3vZclxYjmkdot4VLYMMcpdp8VDzXaix0YmAwU" width=250 height=250></a>
 <a href="https://podcasts.google.com/feed/aHR0cHM6Ly90YWxrcHl0aG9uLmZtL2VwaXNvZGVzL3Jzcw"><img src="https://user-images.githubusercontent.com/24793046/188334448-f50171b9-8501-426e-83f7-553feb376369.png" width=250 height=250></a>
 <a href="https://podcasts.google.com/feed/aHR0cHM6Ly9yZWFscHl0aG9uLmNvbS9wb2RjYXN0cy9ycHAvZmVlZA=="><img src="https://user-images.githubusercontent.com/24793046/188514673-8eaa6c57-338a-46fe-8ae8-160718bb4900.png" width=250 height=250></a>
 <a href="https://podcasts.google.com/feed/aHR0cHM6Ly9tYXBzY2FwaW5nLnBvZGJlYW4uY29tL2ZlZWQueG1s"><img src="https://user-images.githubusercontent.com/24793046/188515031-1c71a2a1-331d-4dec-aafb-34f53f1aa47d.png" width=250 height=250></a>

--- a/google-podcast-downloader.py
+++ b/google-podcast-downloader.py
@@ -1,49 +1,82 @@
+#!/usr/bin/env python3
 """
 Developer: Vaasudevan Srinivasan
 Created on: Aug 25, 2022
 Description: Script to download entire Podcast Library for the given url
 Email: vaasuceg.96@gmail.com
 Github: https://github.com/VaasuDevanS/google-podcast-downloader
+Pull Request by: Hirschy Kirkwood
+Date Submitted: 08/29/23
 """
 
 from bs4 import BeautifulSoup
 import re
 import requests
 from tqdm import tqdm
+import os
+import sys
+
+if len(sys.argv) == 3:
+    url = sys.argv[1]
+    print("URL:", url)
+    out_dir = sys.argv[2]
+    print("Out Dir:", out_dir)
+elif len(sys.argv) == 2:
+    out_dir = r""  # fill in the directory to put your files into.
+else:
+    url = r""  # Fill in your URL here if you don't want to pass cli args.
+    out_dir = r""  # fill in the directory to put your files into.
 
 
-# Specify the URL and the path where the episodes should be downloaded
-url = r''
-out_dir = r''
+class NotEnoughParams(Exception):
+    def __init__(self, message):
+        self.message = message
 
 
-# Read the url and create soup object
-r = requests.get(url)
-soup = BeautifulSoup(r.content, 'html.parser')
+def check_input(out_dir, url):
+    if "~" in out_dir:
+        out_dir = os.path.expanduser(out_dir)
+
+    if not os.path.exists(out_dir):
+        try:
+            os.makedirs(out_dir)
+        except Exception as e:
+            raise ValueError(f"Invalid path: {out_dir}")
+    return out_dir
 
 
-# Get all the divs corresponding to each podcast episode
-divs = soup.find_all('div', attrs={'class': 'oD3fme'})
+if __name__ == "__main__":
+    if not out_dir or not url:
+        raise NotEnoughParams("Please provide both a URL and an output directory.")
+    out_dir = check_input(out_dir, url)
 
+    # Read the url and create soup object
+    r = requests.get(url)
+    soup = BeautifulSoup(r.content, "html.parser")
 
-# Iterate through each div (episode)
-for ix, div in tqdm(enumerate(divs[::-1]), total=len(divs)):
+    # Get all the divs corresponding to each podcast episode
+    divs = soup.find_all("div", attrs={"class": "oD3fme"})
 
-    # Get the date published
-    date = div.find('div', attrs={'class': 'OTz6ee'}).text
+    # Iterate through each div (episode)
+    for ix, div in tqdm(enumerate(divs[::-1]), total=len(divs)):
+        # Get the date published
+        date = div.find("div", attrs={"class": "OTz6ee"}).text
+        # Get the name of the episode
+        name = div.find("div", attrs={"class": "e3ZUqe"}).text
+        name = re.sub('[\/:*?"<>|]+', "", name)
+        file_name = f"EP {ix:03d} - {name} ({date}).mp3"
 
-    # Get the name of the episode and remove invalid characters (Windows)
-    name = div.find('div', attrs={'class': 'e3ZUqe'}).text
-    name = re.sub('[\/:*?"<>|]+', '', name)
-    
-    # Get the URL
-    url = div.find('div', attrs={'jsname': 'fvi9Ef'}).get('jsdata')
-    url = url.split(';')[1]
-    
-    # Construct the File name
-    file_name = f'EP {ix:03d} - {name} ({date})'
-    
-    # Fetch each episode and write the file
-    podcast = requests.get(url)
-    with open(rf'{out_dir}\{file_name}.mp3', 'wb') as out:
-        out.write(podcast.content)    
+        episode_path = os.path.join(out_dir, file_name)
+        if os.path.exists(episode_path):
+            pass  # This file already exists...
+        # Fetch each episode and write the file
+        podcast = requests.get(url)
+
+        # Get the URL
+        url = div.find("div", attrs={"jsname": "fvi9Ef"}).get("jsdata")
+        url = url.split(";")[1]
+
+        # Construct the File name
+
+        with open(rf"{episode_path}", "wb") as out:
+            out.write(podcast.content)

--- a/google-podcast-downloader.py
+++ b/google-podcast-downloader.py
@@ -5,7 +5,7 @@ Created on: Aug 25, 2022
 Description: Script to download entire Podcast Library for the given url
 Email: vaasuceg.96@gmail.com
 Github: https://github.com/VaasuDevanS/google-podcast-downloader
-Pull Request by: Hirschy Kirkwood
+Pull Request by: HirschBerge
 Date Submitted: 08/29/23
 """
 
@@ -23,6 +23,7 @@ if len(sys.argv) == 3:
     print("Out Dir:", out_dir)
 elif len(sys.argv) == 2:
     out_dir = r""  # fill in the directory to put your files into.
+    url = sys.argv[1]
 else:
     url = r""  # Fill in your URL here if you don't want to pass cli args.
     out_dir = r""  # fill in the directory to put your files into.
@@ -70,7 +71,10 @@ if __name__ == "__main__":
         if os.path.exists(episode_path):
             pass  # This file already exists...
         # Fetch each episode and write the file
-        podcast = requests.get(url)
+        try:
+            podcast = requests.get(url)
+        except:
+            pass  # Skips this episode.
 
         # Get the URL
         url = div.find("div", attrs={"jsname": "fvi9Ef"}).get("jsdata")


### PR DESCRIPTION
Summary of changes:
Makes use of builtin os.path to handle paths so this works right on linux.
Uses sys.argv to allow users to add URLs and paths on the fly by calling `python3 google-podcast-downloader "<URL>" "<output_directory>"` and not change the script itself.
Added various error-handling
Added input-checking to ensure user input is correct.
Tested on The Exploring Series to verify that it works.
Previously downloaded episodes will not be downloaded again.